### PR TITLE
Adding new command '/friend' with a single line response (for players)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 target/
 dependency-reduced-pom.xml
+bin/
+.DS_Store
+.gitignore
+.settings
+.classpath
+

--- a/.project
+++ b/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Bukkit-DuckLog</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
               <shadedPattern>org.cyberiantiger.minecraft.ducklog.time</shadedPattern>
             </relocation>
           </relocations>
+          <minimizeJar>true</minimizeJar>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/cyberiantiger/minecraft/log/Main.java
+++ b/src/main/java/org/cyberiantiger/minecraft/log/Main.java
@@ -1,7 +1,5 @@
 package org.cyberiantiger.minecraft.log;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.ByteStreams;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -24,7 +22,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.logging.Level;
-import net.milkbowl.vault.permission.Permission;
+
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
@@ -41,6 +39,7 @@ import org.cyberiantiger.minecraft.log.cmd.AuditCommand;
 import org.cyberiantiger.minecraft.log.cmd.CheckCommand;
 import org.cyberiantiger.minecraft.log.cmd.CommandException;
 import org.cyberiantiger.minecraft.log.cmd.DuckLogCommand;
+import org.cyberiantiger.minecraft.log.cmd.FriendCommand;
 import org.cyberiantiger.minecraft.log.cmd.InvalidSenderException;
 import org.cyberiantiger.minecraft.log.cmd.PermissionException;
 import org.cyberiantiger.minecraft.log.cmd.SeenCommand;
@@ -52,6 +51,11 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.introspector.BeanAccess;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.ByteStreams;
+
+import net.milkbowl.vault.permission.Permission;
 
 public class Main extends JavaPlugin implements Listener {
     private static final String CONFIG = "config.yml";
@@ -228,6 +232,7 @@ public class Main extends JavaPlugin implements Listener {
         commands.put("check", new CheckCommand(this));
         commands.put("ducklog", new DuckLogCommand(this));
         commands.put("timetop", new TimeTopCommand(this));
+        commands.put("friend", new FriendCommand(this));
     }
 
     @Override

--- a/src/main/java/org/cyberiantiger/minecraft/log/cmd/FriendCommand.java
+++ b/src/main/java/org/cyberiantiger/minecraft/log/cmd/FriendCommand.java
@@ -1,0 +1,89 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.cyberiantiger.minecraft.log.cmd;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+import org.bukkit.command.CommandSender;
+import org.cyberiantiger.minecraft.log.LoginEvent;
+import org.cyberiantiger.minecraft.log.Main;
+import org.joda.time.Period;
+import org.joda.time.format.PeriodFormat;
+
+/**
+ *
+ * @author antony & Jabelpeeps
+ */
+public class FriendCommand extends AbstractCommand {
+    private static final Pattern VALID_USERNAME = Pattern.compile("[a-zA-Z0-9_]{2,16}");
+
+
+    public FriendCommand(Main main) {
+        super(main);
+    }
+
+    @Override
+    public List<String> tabComplete(String label, String[] args) {
+        return null;
+    }
+
+    @Override
+    public void execute(final CommandSender sender, String label, String[] args) throws CommandException {
+        if (args.length != 1) throw new UsageException();
+        String target = args[0];
+
+        if (VALID_USERNAME.matcher(target).matches()) {
+            // Name based query.
+            main.getDB().seenName(target, (result) -> {
+                processResult(sender, result);
+            }, (ex) -> {
+                sender.sendMessage(main.getMessage("error"));
+                main.getLogger().log(Level.WARNING, "Error occurred processing friend <name>", ex);
+            });
+        } 
+    }
+
+
+    private void processResult(CommandSender sender, Map<UUID, Map<String, LoginEvent>> result) {
+        if (result.isEmpty()) {
+            sender.sendMessage(main.getMessage("friend.not_found"));
+        } else {
+            result.entrySet().stream().forEach((e) -> {
+                long now = System.currentTimeMillis();
+                boolean f1 = true;
+                boolean f2 = true;
+                StringBuilder aliases = new StringBuilder();
+                for (Map.Entry<String, LoginEvent> ee : e.getValue().entrySet()) {
+                    if (f1) {
+                        f1 = false;
+                        Period period = trimPeriod(now - ee.getValue().getTime());
+                        sender.sendMessage(
+                                main.getMessage("friend.player",
+                                        ee.getKey(), // Name
+                                        ee.getValue().getServer(), // Server
+                                        PeriodFormat.getDefault().print(period) // Time
+                                ));
+                    } else {
+                        if (f2) {
+                            aliases.append(ee.getKey());
+                            f2 = false;
+                        } else {
+                            aliases.append(", ");
+                        }
+                    }
+                    if (e.getValue().size() > 1) {
+                        sender.sendMessage(main.getMessage("seen.alts", aliases.toString()));
+                        aliases.setLength(0);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/cyberiantiger/minecraft/log/config/AutoPromote.java
+++ b/src/main/java/org/cyberiantiger/minecraft/log/config/AutoPromote.java
@@ -36,6 +36,10 @@ public class AutoPromote {
         return addGroup == null ? Collections.emptyList() : addGroup;
     }
 
+    public String getMessage() {
+    	return message;
+    }
+    
     public long getAfter() {
         return after;
     }

--- a/src/main/resources/locale.properties
+++ b/src/main/resources/locale.properties
@@ -9,14 +9,18 @@ seen.not_found=No matching accounts found.
 seen.header=%d matching account(s) found:
 # 1 - last known name, 2 - UUID
 seen.player=%s (%s)
-# 1 - server, 2 - action (logging in / out), 3 - server, 4 - ip
+# 1 - server, 2 - action (logging in / out), 3 - ip
 seen.where.ip=  last seen on %s %s from %s,
-# 1 - server, 2 - action (logging in / out), 3 - server
+# 1 - server, 2 - action (logging in / out)
 seen.where.basic=  last seen on %s %s,
 # 1 - How long ago (period)
 seen.time=  %s ago.
 # 1 - Comma separated aliases.
 seen.alts=  Also known as %s.
+
+friend.not_found=Player not found - did you use the full ign?
+# 1 - last known name, 2 - server, 3 - time
+friend.player=%s last seen on %s on %s ago.
 
 audit.not_found=No matching accounts found.
 # 1 - Number of matches

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -36,7 +36,11 @@ commands:
         timetop:
                 usage: /timetop [server]
                 description: Show the top 10 players by login time, optionally per server.
-                default: op
+                permission: ducklog.timetop
+        friend:
+                usage: /friend <playername>
+                description: Displays when the named player was last online.
+                permission: ducklog.friend
 permissions:
         ducklog.*:
                 description: All ducklog permissions.
@@ -47,6 +51,7 @@ permissions:
                         - ducklog.check
                         - ducklog.reload
                         - ducklog.timetop
+                        - ducklog.friend
         ducklog.seen:
                 description: Allow usage of the /seen command.
                 default: op
@@ -67,3 +72,7 @@ permissions:
                 default: op
         ducklog.timetop:
                 description: Allow usage of the /timetop command.
+                default: op
+        ducklog.friend:
+                description: Allow usage of the /friend command.
+                default: true


### PR DESCRIPTION
Hi there,

I love the plugin, it is (almost) exactly what I was looking for to replace an old - non-bungee, no MySQL, single server only - plugin that used to allow players to use '/seen' to see when their friends had last logged in. 

As you have already used '/seen' to provide a more full-featured information display, I've written this command as '/friend' - though I will probably alias it to '/seen' on my server, as that is what the players are familiar with.

I hope you like the addition; the other changes in the PR are either minor things (like the adding of a missing getter to AutoPromote.java) or things that Eclipse has rearranged for it's own reasons.  (The '<minimizeJar>true</minimizeJar>' in the pom.xml shaved 100k off the compiled .jar size.)

Regards

Jabel
